### PR TITLE
[WiP] Uverb extra header investigation

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
@@ -33,10 +33,10 @@ type family AddSetCookieApiVerb a where
 
 #if MIN_VERSION_servant_server(0,18,2)
 type family AddSetCookieApiUVerb a where
---  AddSetCookieApiUVerb (WithStatus n (Headers (Header "Set-Cookie" SetCookie ': ls) a)) = WithStatus n (Headers (Header "Set-Cookie" SetCookie ': ls) a)
+  AddSetCookieApiUVerb (WithStatus n (Headers (Header "Set-Cookie" SetCookie ': ls) a)) = WithStatus n (Headers (Header "Set-Cookie" SetCookie ': ls) a)
   AddSetCookieApiUVerb (WithStatus n (Headers ls a)) = WithStatus n (Headers (Header "Set-Cookie" SetCookie ': ls) a)
   AddSetCookieApiUVerb (WithStatus n a) = WithStatus n (Headers '[Header "Set-Cookie" SetCookie] a)
---  AddSetCookieApiUVerb (Headers (Header "Set-Cookie" SetCookie ': ls) a) = Headers (Header "Set-Cookie" SetCookie ': ls) a
+  AddSetCookieApiUVerb (Headers (Header "Set-Cookie" SetCookie ': ls) a) = Headers (Header "Set-Cookie" SetCookie ': ls) a
   AddSetCookieApiUVerb (Headers ls a) = Headers (Header "Set-Cookie" SetCookie ': ls) a
   AddSetCookieApiUVerb a = Headers '[Header "Set-Cookie" SetCookie] a
 
@@ -86,10 +86,11 @@ instance {-# OVERLAPPABLE #-}
       Just cookie -> addHeader cookie <$> addSetCookies rest oldVal
 
 #if MIN_VERSION_servant_server(0,18,2)
-instance {-# OVERLAPPING #-}
+{-instance {-# OVERLAPPING #-}
   newA ~ AddSetCookieApiUVerbMap oldA =>
   AddSetCookies ('S n) (m (Union oldA)) (m (Union newA)) where
   addSetCookies = undefined
+-}
 #endif
 
 instance {-# OVERLAPS #-}


### PR DESCRIPTION
- Add `IntResponse`
- Comment out signatures
- Comment out overlapping instance for cookies

- Test:
```
cabal v2-exec --allow-newer -- ghci
ghci> :set -XDataKinds -XTypeOperators -XScopedTypeVariables -XTypeFamilies -XDeriveGeneric -XFlexibleContexts -XOverloadedStrings -XTypeApplications -package cookie -package servant-auth-server
ghci> :l servant-auth-server/test/Servant/Auth/ServerSpec.hs
ghci> :t mkAuthSpec (appUVerb jwtAndCookieApiUVerb)

<interactive>:1:13: error:
    • Couldn't match type: Data.SOP.NS.NS
                             Data.SOP.BasicFunctors.I
                             '[Headers '[Header "Set-Cookie" SetCookie] IntResponse]
                     with: Headers '[Header "Set-Cookie" SetCookie] cookied1
        arising from a use of ‘appUVerb’
    • In the first argument of ‘mkAuthSpec’, namely
        ‘(appUVerb jwtAndCookieApiUVerb)’
      In the expression: mkAuthSpec (appUVerb jwtAndCookieApiUVerb)
```